### PR TITLE
feat: implement race track component

### DIFF
--- a/src/features/race/components/RaceSchedule.vue
+++ b/src/features/race/components/RaceSchedule.vue
@@ -38,16 +38,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useStore } from 'vuex'
+import { formatOrdinal } from '@/utils/formatters'
 
 const store = useStore()
 const schedule = computed(() => store.getters['raceStore/raceSchedule'])
-
-const formatOrdinal = (n: number) => {
-  const s = ['TH', 'ST', 'ND', 'RD']
-  const v = n % 100
-  return n + (s[(v - 20) % 10] || s[v] || s[0])
-}
 </script>
 
-<style scoped>
-</style>

--- a/src/features/race/components/RaceTrack.vue
+++ b/src/features/race/components/RaceTrack.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="p-4">
+    <div class="relative w-full">
+      <div class="h-[400px] bg-gray-100 border rounded overflow-hidden">
+        <div class="absolute left-0 top-0 w-8 bg-gray-200 border-r flex flex-col">
+        <div
+          v-for="i in 10"
+          :key="i"
+          class="h-[40px] flex items-center justify-center font-bold text-gray-600"
+        >
+          {{ i }}
+        </div>
+      </div>
+
+      <div class="ml-8 h-full relative">
+        <div
+          v-for="i in 10"
+          :key="i"
+          class="absolute left-0 w-full border-t border-dashed border-gray-300"
+          :style="{ top: `${i * 40}px` }"
+        />
+
+        <template v-if="activeRound">
+          <div
+            v-for="(horse, index) in activeRound.horses"
+            :key="horse.id"
+            class="absolute transition-all duration-1000 ease-out flex items-center"
+            :style="{
+              top: `${index * 40 + 10}px`,
+              transform: `translateX(${Math.random() * 80 + 10}%)`
+            }"
+          >
+            <span class="inline-block scale-x-[-1]">🐎</span>
+          </div>
+        </template>
+
+      </div>
+    </div>
+    <div class="absolute right-0 top-0 h-full w-1 bg-red-500">
+      <div class="absolute bottom-0 right-2 text-sm font-bold text-red-500">
+        FINISH
+      </div>
+    </div>    
+    <div class="text-center text-sm text-red-600 font-bold">
+      {{ formatOrdinal(currentRound + 1) }} Lap - {{ activeRound?.distance }}m
+    </div>
+  </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useStore } from 'vuex'
+import { formatOrdinal } from '@/utils/formatters'
+
+const store = useStore()
+
+const schedule = computed(() => store.getters['raceStore/raceSchedule'])
+const currentRound = computed(() => store.getters['raceStore/currentRound'])
+
+const activeRound = computed(() => {
+  if (!schedule.value || !Array.isArray(schedule.value) || schedule.value.length === 0) {
+    return null
+  }
+  return schedule.value[currentRound.value] || null
+})
+</script>

--- a/src/pages/GamePage.vue
+++ b/src/pages/GamePage.vue
@@ -3,31 +3,36 @@
       <h1 class="text-white text-xl font-bold">Horse Racing</h1>
       <button class="px-4 py-2 bg-blue-600 text-white rounded" @click="generate">GENERATE PROGRAM</button>
     </div>
-    <div class="grid grid-cols-2 gap-4 p-4">
-      <HorseList />
-      <RaceSchedule v-if="hasGeneratedSchedule" />
+    <div class="grid grid-cols-5 gap-4 p-4">
+      <div class="col-span-1">
+        <HorseList />
+      </div>
+      <div class="col-span-3">
+        <RaceTrack />
+      </div>
+      <div class="col-span-1">
+        <RaceSchedule v-if="hasGeneratedSchedule" />
+      </div>
     </div>
   </template>
   
-  <script setup lang="ts">
-  import { useStore } from 'vuex'
-  import { onMounted, ref } from 'vue'
-  import HorseList from '@/features/horses/components/HorseList.vue'
-  import RaceSchedule from '@/features/race/components/RaceSchedule.vue'
-  
-  const store = useStore()
-  const hasGeneratedSchedule = ref(false)
-  
-  const generate = () => {
-    store.dispatch('raceStore/generateSchedule')
-    hasGeneratedSchedule.value = true
-  }
+<script setup lang="ts">
+import { useStore } from 'vuex'
+import { onMounted, ref } from 'vue'
+import HorseList from '@/features/horses/components/HorseList.vue'
+import RaceSchedule from '@/features/race/components/RaceSchedule.vue'
+import RaceTrack from '@/features/race/components/RaceTrack.vue'
 
-  onMounted(() => {
-    store.dispatch('horseStore/generateHorses')
-  })
-  </script>
-  
-  <style scoped>
-  </style>
+const store = useStore()
+const hasGeneratedSchedule = ref(false)
+
+const generate = () => {
+  store.dispatch('raceStore/generateSchedule')
+  hasGeneratedSchedule.value = true
+}
+
+onMounted(() => {
+  store.dispatch('horseStore/generateHorses')
+})
+</script>
   

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,5 @@
+export const formatOrdinal = (n: number): string => {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0]).toUpperCase()
+} 


### PR DESCRIPTION
## 📌 Summary
- This PR adds the RaceTrack component, which visually displays horses racing across the track.

---

## ✅ Changes
- Created RaceTrack.vue component under features/race/components
- Connected to Vuex to retrieve the current round's horse lineup
- Rendered 10 horses per round in dedicated lanes

---

## 🧠 Reasoning
- The track serves as a visual simulation of each race round. This is a core user-facing element of the game and forms the foundation for dynamic race progression and results.

---

## 🧪 Testing
- Ran npm run dev successfully
- Verified RaceTrack component is visually presented on the game page. 
- Clicked the "GENERATE PROGRAM" button
- Verified horses are positioned in their lane

---

## 📸 Screenshots
![Screenshot 2025-04-07 at 00 53 25](https://github.com/user-attachments/assets/d72c5b79-3bd4-452f-8dca-87accd950ab7)

---

## ⏭️ Next Step
- Add a "Start/Pause" button to trigger sequential round progression.
- Calculate results based on horse condition and save to Vuex.
- Display rankings per round after the race ends.
